### PR TITLE
fix: use ESM syntax highlighter for Astro 5 SSR

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -21,6 +21,23 @@ export default defineConfig(
       react()
     ],
     output: "server",
-    adapter: netlify()
+    adapter: netlify(),
+    vite: {
+      resolve: {
+        alias: [
+          {
+            find: /@babel\/runtime\/helpers\/(?!esm\/)(.*)/,
+            replacement: '@babel/runtime/helpers/esm/$1'
+          },
+          {
+            find: '@babel/runtime/regenerator',
+            replacement: '@babel/runtime/helpers/esm/regeneratorRuntime'
+          }
+        ]
+      },
+      ssr: {
+        noExternal: ['react-syntax-highlighter', 'refractor', '@babel/runtime']
+      }
+    }
   }
 );

--- a/src/components/PortableTextComponents.jsx
+++ b/src/components/PortableTextComponents.jsx
@@ -1,6 +1,6 @@
 import { createSlug } from '../utils/slugify.js';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
+import SyntaxHighlighter from 'react-syntax-highlighter/dist/esm/prism';
+import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
 function extractText(children) {
   if (!children) return '';


### PR DESCRIPTION
Astro 5 executes server routes in strict ESM mode, but our old react-syntax-highlighter imports pulled CommonJS helpers that invoked `require`, which broke post pages in prod. By switching to the ESM prism build and aliasing @babel/runtime helpers to their ESM variants (and bundling them for SSR) the syntax highlighter now runs without triggering `require` at runtime.