### PR TITLE
Add canonical URL support for SEO and content syndication

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,8 @@ import react from "@astrojs/react";
 // https://astro.build/config
 export default defineConfig(
   {
+    site: 'https://esvdev.me', 
+    trailingSlash: 'never',
     integrations: [
       tailwind(), 
       sanity({

--- a/src/components/ZipsCard.astro
+++ b/src/components/ZipsCard.astro
@@ -1,8 +1,9 @@
 ---
 const { zip } = Astro.props;
+const slug = zip.id.replace(/\.md$/, '');
 ---
 
 <div class="card h-full mb-5 p-4 border rounded shadow">
-    <a href={zip.id} class="text-lg font-bold text-orange-500">{zip.data.title}</a>
+    <a href={`/zips/${slug}`} class="text-lg font-bold text-orange-500">{zip.data.title}</a>
     <p class="text-sm mt-2">{zip.data.description}</p>
 </div>

--- a/src/content/zips/shell-vs-terminal.md
+++ b/src/content/zips/shell-vs-terminal.md
@@ -8,7 +8,7 @@ Se suelen usar los términos **terminal** y **shell** de manera intercambiable. 
 
 Antes la expresión "terminal" se utilizaba para referirse a un dispositivo físico que permitía escribir comandos a través de un teclado y ver los resultados en pantalla. Algo así como esto:
 
-![Terminal](https://pbs.twimg.com/media/GcHZW2UWUAA6mFk?format=jpg&name=4096x4096)
+![Terminal](https://i.pcmag.com/imagery/lineups/01BRew0rpQZr6y8VTnrj7jb-1.fit_lim.size_1600x900.v1569492764.jpg)
 
 Hoy por hoy la expresión "terminal" se refiere en realidad a un **emulador de terminal**, es decir, una emulación en software de aquellos dispositivos de antaño.
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,7 +5,15 @@ import Separator from '../components/Separator.astro';
 
 import { ViewTransitions } from 'astro:transitions';
 
-const {pageTitle} = Astro.props;
+interface Props {
+  pageTitle: string;
+  canonicalURL?: string;
+}
+
+const { pageTitle, canonicalURL } = Astro.props;
+
+// Generate canonical URL: use provided one or default to current page URL
+const canonical = canonicalURL || new URL(Astro.url.pathname, Astro.site).href;
 ---
 <html lang="en">
 	<head>
@@ -15,8 +23,10 @@ const {pageTitle} = Astro.props;
 		<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />
+		<!-- Canonical URL -->
+		<link rel="canonical" href={canonical} />
 		<!-- Thumbnail -->
-		<meta property='og:title' content='Esvdev Blog'/>
+		<meta property='og:title' content='esvdev Blog'/>
 		<meta property='og:image' content='/thumbnail/esvdev_blog_thumb.png'/>
 		<meta property='og:description' content="Data Engineering - Python - AWS - Filosofia & Mindset - Career Growth"/>
 		<meta property='og:url' content=''/>
@@ -26,7 +36,7 @@ const {pageTitle} = Astro.props;
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" referrerpolicy="no-referrer" />
 		<!-- Dev Icons -->
 		<link rel="stylesheet" type='text/css' href="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/devicon.min.css" />
-		<title>{pageTitle} - Esvdev</title>
+		<title>{pageTitle} - esvdev</title>
 
 		<ViewTransitions />
 	</head>

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -31,6 +31,9 @@ const POST_BY_SLUG_QUERY = `*[
 const post = await sanityClient.fetch<SanityDocument[]>(POST_BY_SLUG_QUERY);
 const portableText = post.body;
 
+// Generate canonical URL for this post
+const canonicalURL = new URL(`/posts/${slug}`, Astro.site).href;
+
 function addTargetBlankToLinks(html: string) {
     return html.replace(/<a /g, '<a target="_blank" ');
 }
@@ -47,7 +50,7 @@ function formatDate(date: Date){
 }
 
 ---
-<BaseLayout pageTitle={post.title}>
+<BaseLayout pageTitle={post.title} canonicalURL={canonicalURL}>
     <div class="mb-20">
         <h2 class="text-4xl font-bold mb-3 text-orange-500">
             {post.title}

--- a/src/pages/zips/[slug].astro
+++ b/src/pages/zips/[slug].astro
@@ -7,12 +7,13 @@ import { marked } from "marked";
 
 const { slug } = Astro.params;
 const zipsEntries = await getCollection('zips');
-const zip = zipsEntries.find(entry => entry.id === slug);
-const htmlContent = marked.parse(zip.body);
+const zip = zipsEntries.find(entry => entry.id.replace(/\.md$/, '') === slug);
 
 if (!zip) {
     throw new Error(`Zip entry not found for slug: ${slug}`);
 }
+
+const htmlContent = marked.parse(zip.body);
 ---
 
 <BaseLayout pageTitle={zip.data.title}>

--- a/src/pages/zips/index.astro
+++ b/src/pages/zips/index.astro
@@ -12,7 +12,7 @@ const zipsEntries = await getCollection('zips', ({ id }) => {
     <main>
         <h1 class="text-3xl font-bold mb-5">Zips ⚡​</h1>
 
-        <p class="text-lg mb-14 leading-loose">¡Bienvenido/a a <span class="font-bold">Zips</span>! Aquí encontrarás lecturas rápidas sobre tecnología, programación, etc. La idea es que te lleves un aprendizaje, encuentres recursos, o simplemente te diviertas en lecturas breves que no te tomarán más que unos muy pocos minutos.</p>
+        <p class="text-lg mb-14 leading-loose">¡Bienvenido/a a <span class="font-bold">Zips</span>! Aquí encontrarás lecturas rápidas sobre tecnología, programación, etc. La idea es que te lleves un aprendizaje, una reflexión, encuentres recursos, o simplemente te diviertas en lecturas breves de pocos minutos.</p>
 
         <div class="grid lg:grid-cols-2 gap-4">
             {


### PR DESCRIPTION
- Add site URL and trailingSlash config to astro.config.mjs
- Update BaseLayout to accept optional canonicalURL prop
- Auto-generate canonical URL from current page path if not provided
- Add <link rel="canonical"> tag to document head
- Pass canonical URL from post pages to layout

Correct zips collection URL routing
- Fix ZipsCard href to use /zips/{slug} instead of raw entry.id
- Fix [slug].astro to match slug without .md extension
- Move htmlContent parsing after null check to prevent errors