### PR TITLE
chore(seo): update global title suffix to reflect new branding

### DIFF
--- a/src/layouts/SiteLayout.astro
+++ b/src/layouts/SiteLayout.astro
@@ -37,7 +37,10 @@ const canonical = canonicalURL || new URL(Astro.url.pathname, Astro.site).href;
 	<!-- Dev Icons -->
 	<link rel="stylesheet" type='text/css' href="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/devicon.min.css" />
 
-	<title>{pageTitle} - esvdev</title>
+	<title>
+	    {pageTitle === 'El Ingeniero Consciente' ? pageTitle : `${pageTitle} | El Ingeniero Consciente`}
+	</title>
+
 
 	<ViewTransitions />
   </head>


### PR DESCRIPTION
- refactor `<title>` generation in `SiteLayout` to append `| El Ingeniero Consciente` instead of `- esvdev` across all pages
- prevent redundant branding suffix when the page title is already the brand name