### PR TITLE
feat: Refresh about and homepage content

### DIFF
--- a/src/components/AboutHero.astro
+++ b/src/components/AboutHero.astro
@@ -10,7 +10,7 @@ const { title, highlight, imageUrl } = Astro.props;
 
 <section class="max-w-4xl mx-auto px-6 py-16 lg:py-24" data-purpose="about-hero">
   <div class="relative">
-    <div class="mb-10 lg:mb-6 lg:float-left lg:w-5/12 lg:mr-10 mx-auto max-w-sm lg:max-w-none" data-purpose="image-container">
+    <div class="mb-10 lg:mb-6 lg:float-left lg:w-5/12 lg:mr-10 mx-auto max-w-sm lg:max-w-xs" data-purpose="image-container">
       <div class="relative group">
         <div class="absolute -inset-1 bg-gradient-to-r from-gray-800 to-gray-700 rounded-full blur opacity-25 group-hover:opacity-50 transition duration-1000 group-hover:duration-200"></div>
         <img

--- a/src/components/FooterLayout.astro
+++ b/src/components/FooterLayout.astro
@@ -35,7 +35,6 @@ import Social from "./Social.astro";
           </a>
 
           <Social platform="linkedin" username="eliassvelazquez" className="text-brand-offwhite" />
-          <Social platform="twitter" username="ingeconsciente" className="text-brand-offwhite" />
           <Social platform="github" username="eliasvelazquezdev" className="text-brand-offwhite" />
 
           <a
@@ -78,7 +77,6 @@ import Social from "./Social.astro";
       </a>
 
       <Social platform="linkedin" username="eliassvelazquez" className="text-brand-offwhite" />
-      <Social platform="twitter" username="esvdev" className="text-brand-offwhite" />
       <Social platform="github" username="eliasvelazquezdev" className="text-brand-offwhite" />
 
       <a

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -13,14 +13,18 @@ const pageTitle = 'Acerca de'
             highlight="Te cuento un poco sobre mí"
             imageUrl="https://res.cloudinary.com/dwczjy8e4/image/upload/v1743264168/esvdev_pic_2025_3_ixhlpe.png"
         >
-            <p>Comencé mi camino profesional en tecnología en 2024 como Python Developer, donde rápidamente me orienté hacia el mundo del <strong>Data Engineering</strong>.</p>
-            <p>Desde entonces, he trabajado en el desarrollo de soluciones basadas en datos y en la nube, profundizando en herramientas como <strong>AWS</strong>, <strong>Snowflake</strong>, <strong>Docker</strong> y flujos de trabajo modernos que integran IA para resolver problemas de forma más eficiente.</p>
+            <p>Soy Elías, <strong>Data Engineer ubicado en Buenos Aires</strong>. Comencé mi camino profesional en 2024 como desarrollador Python, pero rápidamente encontré mi verdadera vocación en el mundo de los datos y la nube.</p>
 
-            <p>A lo largo de este recorrido, no solo consolidé habilidades técnicas, sino también una forma de trabajar: <strong>clara, colaborativa y orientada a resultados</strong>. La comunicación efectiva, la organización y el trabajo en equipo se volvieron tan importantes como el código, especialmente en entornos remotos y dinámicos.</p>
 
-            <p>Mi enfoque hoy no es solo seguir creciendo como ingeniero, sino hacerlo con criterio. <strong>Me interesa entender el “por qué” detrás de las decisiones técnicas</strong>, construir soluciones sostenibles y mantener una relación consciente con la tecnología que utilizo.</p>
+           <p>Paso mis días charlando con clientes globales sobre cómo puedo aportar a solucionar sus puntos de dolor, construyendo pipelines y diseñando arquitecturas en <strong>AWS</strong>, junto a herramientas como <strong>Snowflake</strong>.</p>
 
-            <p>Esa misma intención es la que me lleva a compartir lo que aprendo, ya sea a través de este espacio o en comunidad. <strong>Creo que la tecnología es una herramienta poderosa para generar impacto, y mi objetivo es contribuir a que más personas puedan desarrollarse en este camino con claridad y confianza</strong>.</p>
+            <p>A lo largo de este recorrido, aprendí que <strong>la comunicación y la organización son tan importantes como el código</strong>. Me interesa entender el “por qué” detrás de cada decisión técnica. Creo firmemente que no tiene sentido construir tecnología sin entender la necesidad humana que la impulsa; al final del día, las computadoras no tienen espíritu ni emociones, las personas sí.</p>
+
+            <p><strong>Esa filosofía es el núcleo de "El Ingeniero Consciente"</strong>, el espacio donde cruzo artículos técnicos (a través de este blog) con reflexiones sobre mentalidad profesional (a través de la newsletter), y de <a href="https://share-it.tech" target="_blank" rel="noopener noreferrer"
+              class="text-brand-orange hover:text-orange-400 transition-colors">ShareIT</a>, la comunidad donde aprendemos y crecemos en equipo.
+            </p>
+
+            <p>Fuera de las pantallas, me vas a encontrar tocando el piano, leyendo sobre filosofía y finanzas, o conectando con personas de trasfondos distintos. Si querés hablar sobre datos o explorar cómo podemos colaborar, ¡escribime! Siempre es un buen momento para una charla.</p>
         </AboutHero>
 
         <ExperienceGrid />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -73,7 +73,7 @@ const pageTitle = 'El Ingeniero Consciente'
         Cada edición gira en torno a uno de estos pilares. Son rutas de lectura
         claras y complementarias.
       </p>
-      <div class='grid grid-cols-1 md:grid-cols-2 gap-6'>
+      <div class='flex flex-col gap-4'>
         <div
           class='p-6 border border-gray-800 rounded-xl bg-white/5 transition-colors hover:border-brand-orange/50'
         >
@@ -106,26 +106,11 @@ const pageTitle = 'El Ingeniero Consciente'
           class='p-6 border border-gray-800 rounded-xl bg-white/5 transition-colors hover:border-brand-orange/50'
         >
           <div class='flex items-center gap-2 mb-2'>
-            <Icon name='briefcase' size={20} className='text-brand-orange' />
-            <h3 class='text-xl font-bold text-brand-offwhite'>
-              Carrera y Habilidades
-            </h3>
-          </div>
-          <p class='text-sm leading-relaxed'>
-            Crecimiento profesional en IT: comunicación, seniority, decisiones y
-            habilidades clave.
-          </p>
-        </div>
-        <div
-          class='p-6 border border-gray-800 rounded-xl bg-white/5 transition-colors hover:border-brand-orange/50'
-        >
-          <div class='flex items-center gap-2 mb-2'>
             <Icon name='brain' size={20} className='text-brand-orange' />
-            <h3 class='text-xl font-bold text-brand-offwhite'>Debug Mental</h3>
+            <h3 class='text-xl font-bold text-brand-offwhite'>Carrera y Debug Mental</h3>
           </div>
           <p class='text-sm leading-relaxed'>
-            Reflexiones, mentalidad y hábitos para sostener el rendimiento sin
-            quemarte.
+              El costado humano del desarrollo profesional. Estrategia laboral, toma de decisiones, foco, hábitos y cómo nuestra mente determina la clase de profesionales que somos.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Update the About page copy to better reflect the site's voice and link to ShareIT with the site's accent styling.

Shrink the About hero image on desktop, switch the newsletter pillars from a grid to a vertical list, refine the career pillar copy, and remove Twitter links from the footer.