### PR TITLE
Unify typography tokens and improve Portable Text rendering

### DIFF
--- a/src/components/PortableTextComponents.jsx
+++ b/src/components/PortableTextComponents.jsx
@@ -67,7 +67,10 @@ export const components = {
       const slug = createSlug(text);
 
       return (
-        <h3 id={slug} className="text-3xl font-medium mt-4 mb-2 scroll-mt-20">
+        <h3
+          id={slug}
+          className="text-2xl font-medium mt-4 mb-2 scroll-mt-20 text-brand-orange-600"
+        >
           {children}
         </h3>
       );
@@ -117,7 +120,7 @@ export const components = {
         href={value?.href}
         target="_blank"
         rel="noopener noreferrer"
-        className="text-blue-600 underline hover:text-blue-800"
+        className="text-brand-orange underline underline-offset-4 transition-opacity hover:opacity-80"
       >
         {children}
       </a>

--- a/src/components/PortableTextComponents.jsx
+++ b/src/components/PortableTextComponents.jsx
@@ -112,19 +112,32 @@ export const components = {
     number: ({ children }) => <li className="ml-4 text-lg">{children}</li>,
   },
 
-  marks: {
+  mark: {
     strong: ({ children }) => <strong>{children}</strong>,
     em: ({ children }) => <em>{children}</em>,
-    link: ({ value, children }) => (
-      <a
-        href={value?.href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-brand-orange underline underline-offset-4 transition-opacity hover:opacity-80"
-      >
+    code: ({ children }) => (
+      <code className="rounded bg-brand-navy-dark px-1.5 py-0.5 font-mono text-sm text-brand-orange-200">
         {children}
-      </a>
+      </code>
     ),
+    link: ({ node, children }) => {
+      const href = node?.markDef?.href || "";
+      const isExternal =
+        href.startsWith("http://") ||
+        href.startsWith("https://") ||
+        href.startsWith("//");
+
+      return (
+        <a
+          href={href}
+          target={isExternal ? "_blank" : undefined}
+          rel={isExternal ? "noopener noreferrer" : undefined}
+          className="text-brand-orange underline underline-offset-4 transition-opacity hover:opacity-80"
+        >
+          {children}
+        </a>
+      );
+    },
   },
 
   type: {

--- a/src/layouts/SiteLayout.astro
+++ b/src/layouts/SiteLayout.astro
@@ -44,7 +44,7 @@ const canonical = canonicalURL || new URL(Astro.url.pathname, Astro.site).href;
 
 	<ViewTransitions />
   </head>
-  <body class="bg-brand-navy text-brand-charcoal selection-highlight antialiased">
+  <body class="bg-brand-navy text-brand-offwhite selection-highlight antialiased">
     <NavigationLayout />
     <slot />
     <FooterLayout />
@@ -58,7 +58,18 @@ const canonical = canonicalURL || new URL(Astro.url.pathname, Astro.site).href;
 
       .selection-highlight::selection {
         background-color: #fca311;
-        color: #14213d;
+        color: #0a1120;
+      }
+
+      strong,
+      b {
+        font-weight: 700;
+        color: #829dd1;
+      }
+
+      em {
+        font-style: italic;
+        color: #a8c0ad;
       }
 
       .narrative-text p {
@@ -70,29 +81,7 @@ const canonical = canonicalURL || new URL(Astro.url.pathname, Astro.site).href;
         margin-bottom: 0;
       }
 
-      article.content p {
-        line-height: 1.8;
-        margin-bottom: 1.75rem;
-        font-size: 1.125rem;
-      }
 
-      article.content h2 {
-        margin-top: 2.5rem;
-        margin-bottom: 1rem;
-        font-size: 1.875rem;
-        color: #fca311;
-      }
-
-      article.content a {
-        color: #fca311;
-        text-decoration: underline;
-        text-underline-offset: 4px;
-        transition: opacity 0.2s;
-      }
-
-      article.content a:hover {
-        opacity: 0.8;
-      }
     </style>
   </body>
 </html>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -50,7 +50,7 @@ const canonicalURL = new URL(`/blog/${slug}`, Astro.site).href;
     </header>
 
     <main class="max-w-4xl mx-auto px-6 pb-24" data-purpose="main-article-content">
-        <article class="content text-brand-accent">
+        <article class="content text-brand-offwhite">
             {post.excerpt && (
                 <p class="text-brand-gray">{post.excerpt}</p>
             )}

--- a/src/pages/blog/zips/[slug].astro
+++ b/src/pages/blog/zips/[slug].astro
@@ -52,7 +52,7 @@ const canonicalURL = new URL(`/blog/zips/${slug}`, Astro.site).href;
             </div>
         </header>
 
-        <article class="content text-brand-accent">
+        <article class="content text-brand-offwhite">
             <PortableText value={portableText} components={components} />
         </article>
 

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,17 +1,114 @@
 /** @type {import('tailwindcss').Config} */
+const offwhiteScale = {
+  50: "#ffffff",
+  100: "#fcfcfc",
+  200: "#f7f7f7",
+  300: "#f1f1f1",
+  400: "#ebebeb",
+  500: "#e5e5e5",
+  600: "#c9c9c9",
+  700: "#a3a3a3",
+  800: "#7a7a7a",
+  900: "#525252",
+  DEFAULT: "#e5e5e5",
+};
+
+const navyScale = {
+  50: "#eef3fb",
+  100: "#d5e0f2",
+  200: "#afc3e4",
+  300: "#829dd1",
+  400: "#5b76bb",
+  500: "#365398",
+  600: "#233a73",
+  700: "#14213d",
+  800: "#0f1a33",
+  900: "#0a1120",
+  DEFAULT: "#14213d",
+};
+
+const navyMidScale = {
+  50: "#edf2fb",
+  100: "#d3ddf1",
+  200: "#acbee1",
+  300: "#8097cb",
+  400: "#5970b2",
+  500: "#3a4f8d",
+  600: "#243569",
+  700: "#172246",
+  800: "#0f1a33",
+  900: "#0a1120",
+  DEFAULT: "#0f1a33",
+};
+
+const navyDarkScale = {
+  50: "#eaf0fb",
+  100: "#cad8f0",
+  200: "#a2b8e0",
+  300: "#7591cb",
+  400: "#4f68b0",
+  500: "#334b8a",
+  600: "#223262",
+  700: "#14203f",
+  800: "#0f182f",
+  900: "#0a1120",
+  DEFAULT: "#0a1120",
+};
+
+const orangeScale = {
+  50: "#fff7e8",
+  100: "#feebc2",
+  200: "#fed68a",
+  300: "#fdbf52",
+  400: "#fcae2a",
+  500: "#fca311",
+  600: "#e28606",
+  700: "#bb6508",
+  800: "#984f0e",
+  900: "#7c4210",
+  DEFAULT: "#fca311",
+};
+
+const grayScale = {
+  50: "#f7f7f7",
+  100: "#ededed",
+  200: "#dcdcdc",
+  300: "#c4c4c4",
+  400: "#a3a3a3",
+  500: "#8a8a8a",
+  600: "#707070",
+  700: "#575757",
+  800: "#3f3f3f",
+  900: "#2b2b2b",
+  DEFAULT: "#a3a3a3",
+};
+
+const sageScale = {
+  50: "#f3f7f4",
+  100: "#e3ece5",
+  200: "#c7d8ca",
+  300: "#a8c0ad",
+  400: "#8eaa95",
+  500: "#73927c",
+  600: "#5d7664",
+  700: "#495c4e",
+  800: "#39473d",
+  900: "#2c3730",
+  DEFAULT: "#73927c",
+};
+
 export default {
   content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
   theme: {
     extend: {
       colors: {
-        "brand-offwhite": "#e5e5e5",
-        "brand-navy": "#14213d",
-        "brand-navy-mid": "#0f1a33",
-        "brand-navy-dark": "#0a1120",
-        "brand-orange": "#fca311",
-        "brand-gray": "#a3a3a3",
-        "brand-charcoal": "#e5e5e5",
-        "brand-accent": "#e5e5e5",
+        "brand-offwhite": offwhiteScale,
+        "brand-navy": navyScale,
+        "brand-navy-mid": navyMidScale,
+        "brand-navy-dark": navyDarkScale,
+        "brand-orange": orangeScale,
+        "brand-sage": sageScale,
+        "brand-gray": grayScale,
       },
     },
   },


### PR DESCRIPTION
This PR aligns site-wide typography with the Portable Text renderer and updates the frontend to match the latest Sanity schema behavior.

### What changed

#### Typography and design tokens
- Added Tailwind shade scales for the brand palette
- Introduced a muted `brand-sage` scale
- Removed redundant `brand-charcoal` and `brand-accent` aliases in favor of `brand-offwhite`
- Unified typography decisions between global site styles and Portable Text
- Removed conflicting article-level typography overrides from `SiteLayout`
- Switched Sanity-rendered links to the brand orange style
- Applied global bold/italic styling for consistent text rendering
- Fixed the italic selector so icon `<i>` tags no longer inherit text-emphasis styles

#### Portable Text improvements
- Fixed custom mark rendering to use the correct `mark` key
- Updated external link rendering to read URLs from `node.markDef.href`
- Ensured external links render with:
  - `target="_blank"`
  - `rel="noopener noreferrer"`
- Added support for inline code marks from the updated Sanity schema
- Styled inline code snippets inside normal paragraphs and lists

### Why
The site had overlapping typography rules between global layout styles and Portable Text rendering, which caused inconsistent presentation across pages and blog content. At the same time, the Sanity schema evolved to support inline code decorators, and external link annotations needed to be rendered correctly.

### Result
- Typography is more consistent across the whole site
- Brand color usage is cleaner and more scalable
- External links from Sanity now open correctly in a new tab
- Inline code inside Portable Text is fully supported and styled properly